### PR TITLE
Fix failing tests on 5.x-dev [no_release]

### DIFF
--- a/tests/System/expected/test___API.getReportPagesMetadata_.xml
+++ b/tests/System/expected/test___API.getReportPagesMetadata_.xml
@@ -279,6 +279,26 @@
 		</subcategory>
 		<widgets>
 			<row>
+				<name>AI Chatbots - No Recent Requests</name>
+				<module>BotTracking</module>
+				<action>noRecentRequestsMessageRealtime</action>
+				<order>0</order>
+				<parameters>
+					<module>BotTracking</module>
+					<action>noRecentRequestsMessageRealtime</action>
+				</parameters>
+				<uniqueId>widgetBotTrackingnoRecentRequestsMessageRealtime</uniqueId>
+				<isWide>1</isWide>
+				<middlewareParameters>
+					<module>BotTracking</module>
+					<action>showNoRecentRequestsMessage</action>
+				</middlewareParameters>
+				<clientComponent>
+					<plugin>BotTracking</plugin>
+					<name>NoRecentRequestsWidget</name>
+				</clientComponent>
+			</row>
+			<row>
 				<name>AI Chatbots - Last 30 Minutes</name>
 				<module>BotTracking</module>
 				<action>getAIChatbotsRealTime</action>


### PR DESCRIPTION
## Description
Automated fix for failing tests on `5.x-dev`.

- Failing workflow: Plugin CustomTranslations Tests
- Failing job(s): PluginTests (matomo5_max_php, maximum_supported_matomo), PluginTests (matomo5_min_php, maximum_supported_matomo)
- CI run: https://github.com/innocraft/plugin-CustomTranslations/actions/runs/29630991349

Generated by automated-test-fixes.

## Issue No
<!-- Mention the issue number this PR addresses. Use GitHub keywords like:
     - Fixes #123 (closes the issue when merged)
     - Resolves #123
     - Related to #123 (if it doesn’t close the issue)
     - JIRA ticket number, if no GitHub issue available
-->

## Steps to Replicate the Issue
1. <!-- Step 1: Describe the action taken. -->
2. <!-- Step 2: What was the expected result? -->
3. <!-- Step 3: What was the actual result? -->



## Checklist
- [✖] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?